### PR TITLE
[BUGFIX] Ignore pushes not including commits

### DIFF
--- a/__tests__/input-helper.test.ts
+++ b/__tests__/input-helper.test.ts
@@ -166,19 +166,18 @@ describe('input-helper tests', () => {
     expect(checkerArguments.messages[0]).toBe('some-title\n\nsome-body')
   })
 
-  it('requires push payload', () => {
+  it('push payload is optional', () => {
     mockGitHub.context = {
       eventName: 'push',
       payload: {}
     }
     inputs.pattern = 'some-pattern'
     inputs.error = 'some-error'
-    expect(() => {
-      const checkerArguments: ICheckerArguments = inputHelper.getInputs()
-    }).toThrow('No commits found in the payload.')
+    const checkerArguments: ICheckerArguments = inputHelper.getInputs()
+    expect(checkerArguments.messages).toHaveLength(0)
   })
 
-  it('requires push payload commits', () => {
+  it('push payload commits is optional', () => {
     mockGitHub.context = {
       eventName: 'push',
       payload: {
@@ -187,9 +186,8 @@ describe('input-helper tests', () => {
     }
     inputs.pattern = 'some-pattern'
     inputs.error = 'some-error'
-    expect(() => {
-      const checkerArguments: ICheckerArguments = inputHelper.getInputs()
-    }).toThrow('No commits found in the payload.')
+    const checkerArguments: ICheckerArguments = inputHelper.getInputs()
+    expect(checkerArguments.messages).toHaveLength(0)
   })
 
   it('sets correct single push payload', () => {

--- a/src/input-helper.ts
+++ b/src/input-helper.ts
@@ -86,9 +86,6 @@ function getMessages(): string[] {
           }
         }
       }
-      if (messages.length === 0) {
-        throw new Error(`No commits found in the payload.`)
-      }
       break
     }
     default: {

--- a/src/main.ts
+++ b/src/main.ts
@@ -28,7 +28,11 @@ import * as commitMessageChecker from './commit-message-checker'
 async function run(): Promise<void> {
   try {
     const checkerArguments = inputHelper.getInputs()
-    await commitMessageChecker.checkCommitMessages(checkerArguments)
+    if (checkerArguments.messages.length === 0) {
+      core.info(`No commits found in the payload, skipping check.`)
+    } else {
+      await commitMessageChecker.checkCommitMessages(checkerArguments)
+    }
   } catch (error) {
     core.error(error)
     core.setFailed(error.message)


### PR DESCRIPTION
Some pushes like tags do not included commits and can be safely ignored.

Closes #6