### PR TITLE
[TASK] Update references to master to new main branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ on: # rebuild any PRs and main branch changes
   pull_request:
   push:
     branches:
-      - master
+      - main
       - 'releases/*'
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ on:
       - synchronize
   push:
     branches:
-      - master
+      - main
       - 'releases/*'
 
 jobs:


### PR DESCRIPTION
This also includes the docs because GitHub will change the default branch to
main for new repositories starting with October 2020 see also
https://github.com/github/renaming.