### PR TITLE
[BUGFIX] Fix the typo in the exception messages

### DIFF
--- a/__tests__/input-helper.test.ts
+++ b/__tests__/input-helper.test.ts
@@ -300,7 +300,7 @@ describe('input-helper tests', () => {
     inputs.error = 'some-error'
     inputs.checkAllCommitMessages = 'true'
     await expect(inputHelper.getInputs()).rejects.toThrow(
-      'The `checkAllCommitMessaages` option requires a github access token.'
+      'The `checkAllCommitMessages` option requires a github access token.'
     )
   })
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -4869,7 +4869,7 @@ function getMessages(pullRequestOptions) {
                 // Handle pull request commits
                 if (pullRequestOptions.checkAllCommitMessages) {
                     if (!pullRequestOptions.accessToken) {
-                        throw new Error('The `checkAllCommitMessaages` option requires a github access token.');
+                        throw new Error('The `checkAllCommitMessages` option requires a github access token.');
                     }
                     if (!github.context.payload.pull_request.number) {
                         throw new Error('No number found in the pull_request.');

--- a/src/input-helper.ts
+++ b/src/input-helper.ts
@@ -145,7 +145,7 @@ async function getMessages(
       if (pullRequestOptions.checkAllCommitMessages) {
         if (!pullRequestOptions.accessToken) {
           throw new Error(
-            'The `checkAllCommitMessaages` option requires a github access token.'
+            'The `checkAllCommitMessages` option requires a github access token.'
           )
         }
 


### PR DESCRIPTION
Hello I have noticed the typo in the messages and decided, with all respect to send a patch for this.
I know the typo fixing PRs are annoying.
If the PR is not welcome please do close it.

Signed-off-by: Tibor Dudlák <tdudlak@redhat.com>