### PR TITLE
[BUGFIX] Fix wrong URL resolution at octokit/grapql queries in Github Enterprise

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 # Dependency directory
 node_modules
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-.idea
 # Dependency directory
 node_modules
 
@@ -98,3 +97,6 @@ Thumbs.db
 # Ignore built ts files
 __tests__/runner/*
 lib/**/*
+
+# Ignore IDE related files and folders
+.idea

--- a/dist/index.js
+++ b/dist/index.js
@@ -5999,6 +5999,7 @@ function getCommitMessagesFromPullRequest(accessToken, repositoryOwner, reposito
   }
 `;
         const variables = {
+            baseUrl: process.env['GITHUB_API_URL'] || 'https://api.github.com',
             repositoryOwner: repositoryOwner,
             repositoryName: repositoryName,
             pullRequestNumber: pullRequestNumber,

--- a/src/input-helper.ts
+++ b/src/input-helper.ts
@@ -251,6 +251,7 @@ async function getCommitMessagesFromPullRequest(
   }
 `
   const variables = {
+    baseUrl: process.env['GITHUB_API_URL'] || 'https://api.github.com',
     repositoryOwner: repositoryOwner,
     repositoryName: repositoryName,
     pullRequestNumber: pullRequestNumber,


### PR DESCRIPTION
Octokit/grapql queries points to wrong Github Urls. When I look into details, I have seen that it is using `https://api.github.com` by default. Made a small change that if there is a Github API URL definition it will use it.

This GITHUB_API_URL comes with Github's own implementation, does not require a manual defined environment variable by  the user.

Note: tried latest version of Octokit, it still has the same problem.