### PR TITLE
[FEATURE] Skip merge commits in pull requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ More information about `pattern` and `flags` can be found in the
 
 `flags` is optional and defaults to `gm`.
 
-`excludeDescription`, `excludeTitle` and `checkAllCommitMessages` are optional.
-Default behavior is to include the description and title and not check pull
-request commit messages.
+`excludeDescription`, `excludeTitle`, `excludeMergeCommits`, and
+`checkAllCommitMessages` are optional. Default behavior is to include the
+description, title, and merge commits, and not check pull request commit messages.
 
 ### Example Workflow
 
@@ -67,8 +67,9 @@ jobs:
           error: 'The maximum line length of 74 characters is exceeded.'
           excludeDescription: 'true' # optional: this excludes the description body of a pull request
           excludeTitle: 'true' # optional: this excludes the title of a pull request
+          excludeMergeCommits: 'true' # optional: this excludes merge commits
           checkAllCommitMessages: 'true' # optional: this checks all commits associated with a pull request
-          accessToken: ${{ secrets.GITHUB_TOKEN }} # github access token is only required if checkAllCommitMessages is true
+          accessToken: ${{ secrets.GITHUB_TOKEN }} # github access token is only required if checkAllCommitMessages or excludeMergeCommits is true
       - name: Check for Resolves / Fixes
         uses: gsactions/commit-message-checker@v2
         with:

--- a/__tests__/commit-message-checker.test.ts
+++ b/__tests__/commit-message-checker.test.ts
@@ -1,7 +1,7 @@
 /*
  * This file is part of the "GS Commit Message Checker" Action for Github.
  *
- * Copyright (C) 2019 by Gilbertsoft LLC (gilbertsoft.org)
+ * Copyright (C) 2019-2022 by Gilbertsoft LLC (gilbertsoft.org)
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,

--- a/__tests__/input-helper.test.ts
+++ b/__tests__/input-helper.test.ts
@@ -553,6 +553,7 @@ describe('input-helper tests', () => {
     expect(checkerArguments.pattern).toBe('some-pattern')
     expect(checkerArguments.error).toBe('some-error')
     expect(checkerArguments.messages).toBeTruthy()
+    expect(checkerArguments.messages.length).toBe(1)
     expect(checkerArguments.messages[0]).toBe('some-message')
   })
 
@@ -566,6 +567,12 @@ describe('input-helper tests', () => {
           },
           {
             message: 'other-message'
+          },
+          {
+            message: 'ignored-message',
+            parents: {
+              totalCount: 2
+            }
           }
         ]
       }
@@ -577,6 +584,7 @@ describe('input-helper tests', () => {
     expect(checkerArguments.pattern).toBe('some-pattern')
     expect(checkerArguments.error).toBe('some-error')
     expect(checkerArguments.messages).toBeTruthy()
+    expect(checkerArguments.messages.length).toBe(2)
     expect(checkerArguments.messages[0]).toBe('some-message')
     expect(checkerArguments.messages[1]).toBe('other-message')
   })

--- a/__tests__/input-helper.test.ts
+++ b/__tests__/input-helper.test.ts
@@ -79,39 +79,20 @@ describe('input-helper tests', () => {
     jest.resetModules()
   })
 
-  it('requires pattern', async () => {
+  it('inputs: requires pattern', async () => {
     await expect(inputHelper.getInputs()).rejects.toThrow(
       'Input required and not supplied: pattern'
     )
   })
 
-  it('requires error message', async () => {
+  it('inputs: requires error message', async () => {
     inputs.pattern = 'some-pattern'
     await expect(inputHelper.getInputs()).rejects.toThrow(
       'Input required and not supplied: error'
     )
   })
 
-  it('requires event', async () => {
-    inputs.pattern = 'some-pattern'
-    inputs.error = 'some-error'
-    await expect(inputHelper.getInputs()).rejects.toThrow(
-      'Event "undefined" is not supported.'
-    )
-  })
-
-  it('requires valid event', async () => {
-    mockGitHub.context = {
-      eventName: 'some-event'
-    }
-    inputs.pattern = 'some-pattern'
-    inputs.error = 'some-error'
-    await expect(inputHelper.getInputs()).rejects.toThrow(
-      'Event "some-event" is not supported.'
-    )
-  })
-
-  it('sets pattern', async () => {
+  it('inputs: sets pattern', async () => {
     mockGitHub.context = {
       eventName: 'pull_request',
       payload: {
@@ -128,7 +109,7 @@ describe('input-helper tests', () => {
     expect(checkerArguments.pattern).toBe('some-pattern')
   })
 
-  it('sets flags', async () => {
+  it('inputs: sets flags', async () => {
     mockGitHub.context = {
       eventName: 'pull_request',
       payload: {
@@ -145,7 +126,7 @@ describe('input-helper tests', () => {
     expect(checkerArguments.flags).toBe('abcdefgh')
   })
 
-  it('sets error', async () => {
+  it('inputs: sets error', async () => {
     mockGitHub.context = {
       eventName: 'pull_request',
       payload: {
@@ -162,7 +143,26 @@ describe('input-helper tests', () => {
     expect(checkerArguments.error).toBe('some-error')
   })
 
-  it('requires pull_request payload', async () => {
+  it('event: requires event', async () => {
+    inputs.pattern = 'some-pattern'
+    inputs.error = 'some-error'
+    await expect(inputHelper.getInputs()).rejects.toThrow(
+      'Event "undefined" is not supported.'
+    )
+  })
+
+  it('event: requires valid event', async () => {
+    mockGitHub.context = {
+      eventName: 'some-event'
+    }
+    inputs.pattern = 'some-pattern'
+    inputs.error = 'some-error'
+    await expect(inputHelper.getInputs()).rejects.toThrow(
+      'Event "some-event" is not supported.'
+    )
+  })
+
+  it('pull_request: requires payload', async () => {
     mockGitHub.context = {
       eventName: 'pull_request'
     }
@@ -173,7 +173,7 @@ describe('input-helper tests', () => {
     )
   })
 
-  it('requires pull_request', async () => {
+  it('pull_request: requires pull_request payload', async () => {
     mockGitHub.context = {
       eventName: 'pull_request',
       payload: {}
@@ -185,7 +185,7 @@ describe('input-helper tests', () => {
     )
   })
 
-  it('requires pull_request title', async () => {
+  it('pull_request: requires title', async () => {
     mockGitHub.context = {
       eventName: 'pull_request',
       payload: {
@@ -202,7 +202,7 @@ describe('input-helper tests', () => {
     )
   })
 
-  it('sets pull_request title', async () => {
+  it('pull_request: sets title', async () => {
     mockGitHub.context = {
       eventName: 'pull_request',
       payload: {
@@ -220,7 +220,7 @@ describe('input-helper tests', () => {
     expect(checkerArguments.messages[0]).toBe('some-title')
   })
 
-  it('sets pull_request title and body', async () => {
+  it('pull_request: sets title and body', async () => {
     mockGitHub.context = {
       eventName: 'pull_request',
       payload: {
@@ -238,7 +238,7 @@ describe('input-helper tests', () => {
     expect(checkerArguments.messages[0]).toBe('some-title\n\nsome-body')
   })
 
-  it('excludes pull_request body', async () => {
+  it('pull_request: excludes body', async () => {
     mockGitHub.context = {
       eventName: 'pull_request',
       payload: {
@@ -257,7 +257,7 @@ describe('input-helper tests', () => {
     expect(checkerArguments.messages[0]).toBe('some-title')
   })
 
-  it('excludes pull_request title', async () => {
+  it('pull_request: excludes title', async () => {
     mockGitHub.context = {
       eventName: 'pull_request',
       payload: {
@@ -276,7 +276,7 @@ describe('input-helper tests', () => {
     expect(checkerArguments.messages[0]).toBe('some-body')
   })
 
-  it('excludes pull_request title and body', async () => {
+  it('pull_request: excludes title and body', async () => {
     mockGitHub.context = {
       eventName: 'pull_request',
       payload: {
@@ -296,7 +296,7 @@ describe('input-helper tests', () => {
     expect(checkerArguments.messages.length).toBe(0)
   })
 
-  it('requires accessToken', async () => {
+  it('pull_request: requires accessToken', async () => {
     mockGitHub.context = {
       eventName: 'pull_request',
       payload: {
@@ -314,7 +314,7 @@ describe('input-helper tests', () => {
     )
   })
 
-  it('requires pull_request number', async () => {
+  it('pull_request: requires number', async () => {
     mockGitHub.context = {
       eventName: 'pull_request',
       payload: {
@@ -333,7 +333,7 @@ describe('input-helper tests', () => {
     )
   })
 
-  it('requires repository', async () => {
+  it('pull_request: requires repository', async () => {
     mockGitHub.context = {
       eventName: 'pull_request',
       payload: {
@@ -353,7 +353,7 @@ describe('input-helper tests', () => {
     )
   })
 
-  it('requires repository name', async () => {
+  it('pull_request: requires repository name', async () => {
     mockGitHub.context = {
       eventName: 'pull_request',
       payload: {
@@ -374,7 +374,7 @@ describe('input-helper tests', () => {
     )
   })
 
-  it('requires repository owner (1)', async () => {
+  it('pull_request: requires repository owner (1)', async () => {
     mockGitHub.context = {
       eventName: 'pull_request',
       payload: {
@@ -397,7 +397,7 @@ describe('input-helper tests', () => {
     )
   })
 
-  it('requires repository owner (2)', async () => {
+  it('pull_request: requires repository owner (2)', async () => {
     mockGitHub.context = {
       eventName: 'pull_request',
       payload: {
@@ -421,7 +421,7 @@ describe('input-helper tests', () => {
     )
   })
 
-  it('sets pull_request commits', async () => {
+  it('pull_request: sets commits', async () => {
     mockGitHub.context = {
       eventName: 'pull_request',
       payload: {
@@ -507,10 +507,98 @@ describe('input-helper tests', () => {
     expect(checkerArguments.pattern).toBe('some-pattern')
     expect(checkerArguments.error).toBe('some-error')
     expect(checkerArguments.messages).toBeTruthy()
+    expect(checkerArguments.messages.length).toBe(4)
+  })
+
+  it('pull_request: excludes merge commits', async () => {
+    mockGitHub.context = {
+      eventName: 'pull_request',
+      payload: {
+        pull_request: {
+          title: 'some-title',
+          body: 'some-body',
+          number: 1
+        },
+        repository: {
+          owner: {
+            name: 'some-owner'
+          },
+          name: 'some-repo'
+        }
+      }
+    }
+
+    inputs.pattern = 'some-pattern'
+    inputs.error = 'some-error'
+    inputs.excludeDescription = 'true'
+    inputs.excludeTitle = 'true'
+    inputs.excludeMergeCommits = 'true'
+    inputs.checkAllCommitMessages = 'true'
+    inputs.accessToken = 'some-token'
+
+    const response = {
+      repository: {
+        pullRequest: {
+          commits: {
+            edges: [
+              {
+                node: {
+                  commit: {
+                    message:
+                      'input: make input-helper functions async\n\nIn order to work with asynchronous call like an async http request\nin an easier way, the functions getInput and getMessages were\nconverted to async.',
+                    parents: {
+                      totalCount: 1
+                    }
+                  }
+                }
+              },
+              {
+                node: {
+                  commit: {
+                    message:
+                      "input: PR options ignore title and check PR commits\n\nthis make it possible to igore partially or completely the PR payload.\nThe commits associated with the pull request can be checked instead of\nchecking the pull request payload. The parameter are:\n\n- excludeTitle: 'true | false'\n- excludeDescription: 'true | false'\n- checkAllCommitMessages: 'true | false'\n\nby default, all options comes false.",
+                    parents: {
+                      totalCount: 1
+                    }
+                  }
+                }
+              },
+              {
+                node: {
+                  commit: {
+                    message:
+                      'docs: include parameters excludeTitle, checkAllCommitMessages and accessToken\n\nCo-authored-by: Gilbertsoft <25326036+gilbertsoft@users.noreply.github.com>',
+                    parents: {
+                      totalCount: 1
+                    }
+                  }
+                }
+              },
+              {
+                node: {
+                  commit: {
+                    message: 'merge: merge commit to be ignored',
+                    parents: {
+                      totalCount: 2
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+
+    graphqlResponse = response
+
+    const checkerArguments: ICheckerArguments = await inputHelper.getInputs()
+    expect(checkerArguments).toBeTruthy()
+    expect(checkerArguments.messages).toBeTruthy()
     expect(checkerArguments.messages.length).toBe(3)
   })
 
-  it('require push payload', async () => {
+  it('push: requires payload property', async () => {
     mockGitHub.context = {
       eventName: 'push'
     }
@@ -521,7 +609,7 @@ describe('input-helper tests', () => {
     )
   })
 
-  it('push payload is optional', async () => {
+  it('push: payload content is optional', async () => {
     mockGitHub.context = {
       eventName: 'push',
       payload: {}
@@ -532,7 +620,7 @@ describe('input-helper tests', () => {
     expect(checkerArguments.messages).toHaveLength(0)
   })
 
-  it('push payload commits is optional', async () => {
+  it('push: payload commits is optional', async () => {
     mockGitHub.context = {
       eventName: 'push',
       payload: {
@@ -545,7 +633,97 @@ describe('input-helper tests', () => {
     expect(checkerArguments.messages).toHaveLength(0)
   })
 
-  it('sets correct single push payload', async () => {
+  it('push: requires repository', async () => {
+    mockGitHub.context = {
+      eventName: 'push',
+      payload: {
+        commits: [
+          {
+            id: '1',
+            message: 'some-message'
+          }
+        ]
+      }
+    }
+    inputs.pattern = 'some-pattern'
+    inputs.error = 'some-error'
+    await expect(inputHelper.getInputs()).rejects.toThrow(
+      'No repository found in the payload.'
+    )
+  })
+
+  it('push: requires repository name', async () => {
+    mockGitHub.context = {
+      eventName: 'push',
+      payload: {
+        commits: [
+          {
+            id: '1',
+            message: 'some-message'
+          }
+        ],
+        repository: {}
+      }
+    }
+    inputs.pattern = 'some-pattern'
+    inputs.error = 'some-error'
+    inputs.checkAllCommitMessages = 'true'
+    inputs.accessToken = 'dummy-token'
+    await expect(inputHelper.getInputs()).rejects.toThrow(
+      'No name found in the repository.'
+    )
+  })
+
+  it('push: requires repository owner (1)', async () => {
+    mockGitHub.context = {
+      eventName: 'push',
+      payload: {
+        commits: [
+          {
+            id: '1',
+            message: 'some-message'
+          }
+        ],
+        repository: {
+          name: 'repository-name'
+        }
+      }
+    }
+    inputs.pattern = 'some-pattern'
+    inputs.error = 'some-error'
+    inputs.checkAllCommitMessages = 'true'
+    inputs.accessToken = 'dummy-token'
+    await expect(inputHelper.getInputs()).rejects.toThrow(
+      'No owner found in the repository.'
+    )
+  })
+
+  it('push: requires repository owner (2)', async () => {
+    mockGitHub.context = {
+      eventName: 'push',
+      payload: {
+        commits: [
+          {
+            id: '1',
+            message: 'some-message'
+          }
+        ],
+        repository: {
+          name: 'repository-name',
+          owner: {}
+        }
+      }
+    }
+    inputs.pattern = 'some-pattern'
+    inputs.error = 'some-error'
+    inputs.checkAllCommitMessages = 'true'
+    inputs.accessToken = 'dummy-token'
+    await expect(inputHelper.getInputs()).rejects.toThrow(
+      'No owner found in the repository.'
+    )
+  })
+
+  it('push: sets single commit correctly', async () => {
     mockGitHub.context = {
       eventName: 'push',
       payload: {
@@ -589,7 +767,7 @@ describe('input-helper tests', () => {
     expect(checkerArguments.messages[0]).toBe('some-message')
   })
 
-  it('sets correct multiple push payload', async () => {
+  it('push: sets multiple commits correctly', async () => {
     mockGitHub.context = {
       eventName: 'push',
       payload: {
@@ -604,7 +782,7 @@ describe('input-helper tests', () => {
           },
           {
             id: '3',
-            message: 'ignored-message'
+            message: 'merge-commit-message'
           }
         ],
         repository: {
@@ -624,7 +802,7 @@ describe('input-helper tests', () => {
         return {
           repository: {
             object: {
-              message: 'ignored-message',
+              message: 'merge-commit-message',
               parents: {
                 totalCount: 2
               }
@@ -649,8 +827,101 @@ describe('input-helper tests', () => {
     expect(checkerArguments.pattern).toBe('some-pattern')
     expect(checkerArguments.error).toBe('some-error')
     expect(checkerArguments.messages).toBeTruthy()
-    expect(checkerArguments.messages.length).toBe(2)
+    expect(checkerArguments.messages.length).toBe(3)
     expect(checkerArguments.messages[0]).toBe('some-message')
     expect(checkerArguments.messages[1]).toBe('other-message')
+  })
+
+  it('push: requires accessToken to exclude merge commits', async () => {
+    mockGitHub.context = {
+      eventName: 'push',
+      payload: {
+        commits: [
+          {
+            id: '1',
+            message: 'some-message'
+          }
+        ],
+        repository: {
+          owner: {
+            name: 'some-owner'
+          },
+          name: 'some-repo'
+        }
+      }
+    }
+
+    inputs.pattern = 'some-pattern'
+    inputs.error = 'some-error'
+    inputs.excludeMergeCommits = 'true'
+
+    await expect(inputHelper.getInputs()).rejects.toThrow(
+      'The `excludeMergeCommits` option requires a github access token.'
+    )
+  })
+
+  it('push: excludes merge commits', async () => {
+    mockGitHub.context = {
+      eventName: 'push',
+      payload: {
+        commits: [
+          {
+            id: '1',
+            message: 'merge-commit-message-1'
+          },
+          {
+            id: '2',
+            message: 'some-message'
+          },
+          {
+            id: '3',
+            message: 'merge-commit-message-2'
+          }
+        ],
+        repository: {
+          owner: {
+            name: 'some-owner'
+          },
+          name: 'some-repo'
+        }
+      }
+    }
+
+    inputs.pattern = 'some-pattern'
+    inputs.error = 'some-error'
+    inputs.excludeMergeCommits = 'true'
+    inputs.accessToken = 'some-token'
+
+    getGraphqlResponse = (parameters?: any): any => {
+      if (parameters.commitSha === '2') {
+        return {
+          repository: {
+            object: {
+              message: 'some-message',
+              parents: {
+                totalCount: 1
+              }
+            }
+          }
+        }
+      }
+
+      return {
+        repository: {
+          object: {
+            parents: {
+              totalCount: 2
+            }
+          }
+        }
+      }
+    }
+
+    const checkerArguments: ICheckerArguments = await inputHelper.getInputs()
+    expect(checkerArguments).toBeTruthy()
+    expect(checkerArguments.pattern).toBe('some-pattern')
+    expect(checkerArguments.error).toBe('some-error')
+    expect(checkerArguments.messages).toBeTruthy()
+    expect(checkerArguments.messages.length).toBe(1)
   })
 })

--- a/__tests__/input-helper.test.ts
+++ b/__tests__/input-helper.test.ts
@@ -445,7 +445,10 @@ describe('input-helper tests', () => {
                 node: {
                   commit: {
                     message:
-                      'input: make input-helper functions async\n\nIn order to work with asynchronous call like an async http request\nin an easier way, the functions getInput and getMessages were\nconverted to async.'
+                      'input: make input-helper functions async\n\nIn order to work with asynchronous call like an async http request\nin an easier way, the functions getInput and getMessages were\nconverted to async.',
+                    parents: {
+                      totalCount: 1
+                    }
                   }
                 }
               },
@@ -453,7 +456,10 @@ describe('input-helper tests', () => {
                 node: {
                   commit: {
                     message:
-                      "input: PR options ignore title and check PR commits\n\nthis make it possible to igore partially or completely the PR payload.\nThe commits associated with the pull request can be checked instead of\nchecking the pull request payload. The parameter are:\n\n- excludeTitle: 'true | false'\n- excludeDescription: 'true | false'\n- checkAllCommitMessages: 'true | false'\n\nby default, all options comes false."
+                      "input: PR options ignore title and check PR commits\n\nthis make it possible to igore partially or completely the PR payload.\nThe commits associated with the pull request can be checked instead of\nchecking the pull request payload. The parameter are:\n\n- excludeTitle: 'true | false'\n- excludeDescription: 'true | false'\n- checkAllCommitMessages: 'true | false'\n\nby default, all options comes false.",
+                    parents: {
+                      totalCount: 1
+                    }
                   }
                 }
               },
@@ -461,7 +467,20 @@ describe('input-helper tests', () => {
                 node: {
                   commit: {
                     message:
-                      'docs: include parameters excludeTitle, checkAllCommitMessages and accessToken\n\nCo-authored-by: Gilbertsoft <25326036+gilbertsoft@users.noreply.github.com>'
+                      'docs: include parameters excludeTitle, checkAllCommitMessages and accessToken\n\nCo-authored-by: Gilbertsoft <25326036+gilbertsoft@users.noreply.github.com>',
+                    parents: {
+                      totalCount: 1
+                    }
+                  }
+                }
+              },
+              {
+                node: {
+                  commit: {
+                    message: 'merge: merge commit to be ignored',
+                    parents: {
+                      totalCount: 2
+                    }
                   }
                 }
               }

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,10 @@ inputs:
     description: 'Setting this input to true will exclude the Pull Request description from the check.'
     required: false
     default: 'false'
+  excludeMergeCommits:
+    description: 'Setting this input to true will exclude merge commits from the check.'
+    required: false
+    default: 'false'
   checkAllCommitMessages:
     description: 'Setting this input to true will check all Pull Request commits'
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -344,7 +344,10 @@ function getCommitMessagesFromPullRequest(accessToken, repositoryOwner, reposito
           edges {
             node {
               commit {
-                message
+                message,
+                parents(last: 1) {
+                  totalCount
+                }
               }
             }
           }
@@ -369,7 +372,15 @@ function getCommitMessagesFromPullRequest(accessToken, repositoryOwner, reposito
         core.debug(` - response: ${JSON.stringify(repository, null, 2)}`);
         let messages = [];
         if (repository.pullRequest) {
-            messages = repository.pullRequest.commits.edges.map(function (edge) {
+            messages = repository.pullRequest.commits.edges
+                .filter(function (edge) {
+                if (edge.node.commit.parents.totalCount > 1) {
+                    // Skip merge commits (which have more than 1 parent commit)
+                    return false;
+                }
+                return true;
+            })
+                .map(function (edge) {
                 return edge.node.commit.message;
             });
         }

--- a/dist/index.js
+++ b/dist/index.js
@@ -236,7 +236,7 @@ exports.getInputs = getInputs;
  * @returns   string[]
  */
 function getMessages(pullRequestOptions) {
-    var _a;
+    var _a, _b, _c;
     return __awaiter(this, void 0, void 0, function* () {
         core.debug('Get messages...');
         core.debug(` - pullRequestOptions: ${JSON.stringify(pullRequestOptions, null, 2)}`);
@@ -311,7 +311,9 @@ function getMessages(pullRequestOptions) {
                     break;
                 }
                 for (const i in github.context.payload.commits) {
-                    if (github.context.payload.commits[i].message) {
+                    if (github.context.payload.commits[i].message &&
+                        // ignore merge commits
+                        ((_c = (_b = github.context.payload.commits[i].parents) === null || _b === void 0 ? void 0 : _b.totalCount) !== null && _c !== void 0 ? _c : 1) === 1) {
                         messages.push(github.context.payload.commits[i].message);
                     }
                 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -376,11 +376,8 @@ function getCommitMessagesFromPullRequest(accessToken, repositoryOwner, reposito
         if (repository.pullRequest) {
             messages = repository.pullRequest.commits.edges
                 .filter(function (edge) {
-                if (edge.node.commit.parents.totalCount > 1) {
-                    // Skip merge commits (which have more than 1 parent commit)
-                    return false;
-                }
-                return true;
+                // Skip merge commits (which have more than 1 parent commit)
+                return edge.node.commit.parents.totalCount === 1;
             })
                 .map(function (edge) {
                 return edge.node.commit.message;

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "format-check": "prettier --check '**/*.ts'",
     "lint": "eslint src/**/*.ts",
     "package": "ncc build",
-    "test": "jest",
+    "test": "jest --coverage",
     "all": "npm run build && npm run format && npm run lint && npm run package && npm test"
   },
   "dependencies": {

--- a/src/input-helper.ts
+++ b/src/input-helper.ts
@@ -301,11 +301,8 @@ async function getCommitMessagesFromPullRequest(
   if (repository.pullRequest) {
     messages = repository.pullRequest.commits.edges
       .filter(function (edge: CommitEdgeItem): boolean {
-        if (edge.node.commit.parents.totalCount > 1) {
-          // Skip merge commits (which have more than 1 parent commit)
-          return false
-        }
-        return true
+        // Skip merge commits (which have more than 1 parent commit)
+        return edge.node.commit.parents.totalCount === 1
       })
       .map(function (edge: CommitEdgeItem): string {
         return edge.node.commit.message

--- a/src/input-helper.ts
+++ b/src/input-helper.ts
@@ -201,7 +201,11 @@ async function getMessages(
       }
 
       for (const i in github.context.payload.commits) {
-        if (github.context.payload.commits[i].message) {
+        if (
+          github.context.payload.commits[i].message &&
+          // ignore merge commits
+          (github.context.payload.commits[i].parents?.totalCount ?? 1) === 1
+        ) {
           messages.push(github.context.payload.commits[i].message)
         }
       }


### PR DESCRIPTION
Merge commits can be identified by having two parent commits, so we add to the GraphQL query selecting PR commits to also return `parents.totalCount`. This shows any standard commit having 1 parent, and merge commits having 2.

We can then `.filter()` out those instances before mapping commit messages.

Should fix #75 

---

Note that TypeScript/JavaScript are not my strong suit. I would appreciate assistance in adding tests and perhaps bringing the same check to the `push` event.