### PR TITLE
Bump actions runner to node20 #100

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -29,7 +29,7 @@ inputs:
     required: false
     default: 'false'  
 runs:
-  using: node16
+  using: node20
   main: dist/index.js
 branding:
   icon: 'check'


### PR DESCRIPTION
This PR bumps the actions runner to node20.

If you would like, I feel the following should likely be addressed as well, and I am happy to knock them out:
- [ ] Bump the package version to 3.0.0 (2.1.0?)
- [ ] Bump NPM dependencies

Fixes #100