### PR TITLE
Fix regex in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ jobs:
       - name: Check Line Length
         uses: gsactions/commit-message-checker@v2
         with:
-          pattern: '^[^#].{74}'
+          pattern: '^[^#].{1,74}'
           error: 'The maximum line length of 74 characters is exceeded.'
           excludeDescription: 'true' # optional: this excludes the description body of a pull request
           excludeTitle: 'true' # optional: this excludes the title of a pull request


### PR DESCRIPTION
Currently, the regex in the `Check Line Length` step fails commits that have less than 74 characters. This regex is most likely what users want - fail for commit messages that are longer than 74 chars, but pass for commit messages that are shorter than 74 chars .